### PR TITLE
block validator WIP

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -534,19 +534,10 @@ fn validate_block<T, N5>(
         data_attrs,
         coord.to_vec());
 
-    let expected_numel : i32 = data_attrs.get_block_size().to_vec().iter().product();
-
     match block_opt {
-        Ok(o) => match o {
-            Some(b) =>
-                if b.get_num_elements() == expected_numel {
-                    Ok(None)
-                } else {
-                    Ok(Some(coord))
-                },
-            None => Ok(None),
-        },
+        // todo: incorrect block size only raises for uint8
+        Ok(_o) => Ok(None),
         // todo: different handling for different types of error
-        Err(_e) => Ok(Some(coord))
+        Err(_e) => Ok(Some(coord)),
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -245,7 +245,7 @@ fn bench_read<N5>(
     };
 
     let coord_iter = data_attrs.coord_iter();
-    let total_coords = coord_iter.size_hint().0;
+    let total_coords = coord_iter.len();
     let bar = Arc::new(RwLock::new(ProgressBar::new(total_coords as u64)));
     bar.write().unwrap().set_draw_target(ProgressDrawTarget::stderr());
 
@@ -340,7 +340,7 @@ fn recompress<N5I, N5O>(
     };
 
     let coord_iter = data_attrs_in.coord_iter();
-    let total_coords = coord_iter.size_hint().0;
+    let total_coords = coord_iter.len();
     let bar = Arc::new(RwLock::new(ProgressBar::new(total_coords as u64)));
     bar.write().unwrap().set_draw_target(ProgressDrawTarget::stderr());
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -37,6 +37,7 @@ use num_traits::{
 };
 use prettytable::Table;
 use structopt::StructOpt;
+use std::path::Path;
 
 /// Utilities for N5 files.
 #[derive(StructOpt, Debug)]
@@ -73,6 +74,16 @@ enum Command {
     /// compression.
     #[structopt(name = "recompress")]
     Recompress(RecompressOptions),
+    /// Report malformed blocks.
+    #[structopt(name = "validate-blocks")]
+    ValidateBlocks {
+        /// Input N5 root path
+        #[structopt(name = "N5")]
+        n5_path: String,
+        /// Input N5 dataset
+        #[structopt(name = "DATASET")]
+        dataset: String,
+    },
 }
 
 #[derive(StructOpt, Debug)]
@@ -222,6 +233,27 @@ fn main() {
             println!("Converted {} (uncompressed) in {}",
                 HumanBytes(num_bytes as u64),
                 HumanDuration(started.elapsed()));
+        },
+        Command::ValidateBlocks {n5_path, dataset} => {
+            let n = N5Filesystem::open(&n5_path).unwrap();
+            let started = Instant::now();
+            let invalid_blocks = get_invalid_blocks(
+                &n,
+                &dataset,
+                opt.threads).unwrap();
+            for block_idx in invalid_blocks.iter() {
+                // todo: would prefer to use get_data_block_path, but it's private
+                // println!("{}", n.get_data_block_path(&dataset, &block_idx)?.display());
+
+                // todo: handle edge cases like get_data_block_path?
+                let mut block_path = Path::new(&n5_path).join(&dataset);
+                for val in block_idx.iter() {
+                    block_path.push(val.to_string());
+                }
+                println!("{}", block_path.display());
+            }
+            eprintln!("Found {} invalid block(s) in {}",
+                invalid_blocks.len(), HumanDuration(started.elapsed()));
         },
     }
 }
@@ -414,4 +446,107 @@ fn recompress_block<T, N5I, N5O>(
     };
 
     Ok(num_vox)
+}
+
+fn get_invalid_blocks<N5>(
+    n: &N5,
+    dataset: &str,
+    pool_size: Option<usize>,
+) -> Result<Vec<Vec<i64>>>
+    where N5: N5Reader + Sync + Send + Clone + 'static {
+
+
+    // todo: copied from bench_read; refactor
+    let data_attrs = n.get_dataset_attributes(dataset)?;
+
+    let mut all_jobs: Vec<CpuFuture<Option<Vec<i64>>, std::io::Error>> =
+        Vec::new();
+    let pool = match pool_size {
+        Some(threads) => CpuPool::new(threads),
+        None => CpuPool::new_num_cpus(),
+    };
+
+    let coord_ceil = data_attrs.get_dimensions().iter()
+        .zip(data_attrs.get_block_size().iter())
+        .map(|(&d, &s)| (d + i64::from(s) - 1) / i64::from(s))
+        .collect::<Vec<_>>();
+    let total_coords: i64 = coord_ceil.iter().product();
+    let coord_iter = coord_ceil.into_iter()
+        .map(|c| 0..c)
+        .multi_cartesian_product();
+
+    let bar = Arc::new(RwLock::new(ProgressBar::new(total_coords as u64)));
+
+    for coord in coord_iter {
+        let n_c = n.clone();
+        let dataset_c = dataset.to_owned();
+        let data_attrs_c = data_attrs.clone();
+        let bar_c = bar.clone();
+        all_jobs.push(pool.spawn_fn(move || {
+            // TODO: Have to work around annoying reflection issue.
+            let results = match *data_attrs_c.get_data_type() {
+                DataType::UINT8 => validate_block::<u8, _>(
+                    &n_c,
+                    &dataset_c,
+                    &data_attrs_c,
+                    coord)?,
+                _ => unimplemented!(),
+                // DataType::UINT16 => std::mem::size_of::<u16>(),
+                // DataType::UINT32 => std::mem::size_of::<u32>(),
+                // DataType::UINT64 => std::mem::size_of::<u64>(),
+                // DataType::INT8 => std::mem::size_of::<i8>(),
+                // DataType::INT16 => std::mem::size_of::<i16>(),
+                // DataType::INT32 => std::mem::size_of::<i32>(),
+                // DataType::INT64 => std::mem::size_of::<i64>(),
+                // DataType::FLOAT32 => std::mem::size_of::<f32>(),
+                // DataType::FLOAT64 => std::mem::size_of::<f64>(),
+            };
+            bar_c.write().unwrap().inc(1);
+            Ok(results)
+        }));
+    }
+
+    let mut block_idxs : Vec<Vec<i64>> = Vec::new();
+
+    for result in futures::future::join_all(all_jobs).wait()?.iter() {
+        match result {
+            Some(v) => block_idxs.push(v.to_vec()),
+            None => {},
+        }
+    }
+
+    Ok(block_idxs)
+}
+
+fn validate_block<T, N5>(
+    n5: &N5,
+    dataset: &str,
+    data_attrs: &DatasetAttributes,
+    coord: Vec<i64>,
+) -> Result<Option<Vec<i64>>>
+    where T: 'static + std::fmt::Debug + Clone + PartialEq + Sync + Send,
+          N5: N5Reader + Sync + Send + Clone + 'static,
+          DataType: TypeReflection<T> + DataBlockCreator<T>,
+          VecDataBlock<T>: n5::ReadableDataBlock + n5::WriteableDataBlock {
+
+    let block_opt = n5.read_block::<T>(
+        dataset,
+        data_attrs,
+        coord.to_vec());
+
+    let expected_numel : i32 = data_attrs.get_block_size().to_vec().iter().product();
+
+    match block_opt {
+        Ok(o) => match o {
+            Some(b) =>
+                if b.get_num_elements() == expected_numel {
+                    Ok(None)
+                } else {
+                    Ok(Some(coord))
+                },
+            None => Ok(None),
+        },
+        // todo: different handling for different types of error
+        Err(_e) => Ok(Some(coord))
+    }
 }


### PR DESCRIPTION
First stab at this (i.e. copy your code, misread the rust docs, stop debugging as soon as traits are mentioned).

What (I think) I want: 
- Print paths to invalid blocks to stdout, for piping to things

I've shied away from `println!` inside the future in case it craps out halfway through, although if one is just piping to `rm` or dumping to a file I suppose that doesn't matter much. Printing inside the future would simplify matters a lot, but I suppose the caller might want to do something else with it. Waiting until the end also means the output doesn't interfere with the progress bar, which is monitoring the slow bit.

The futures return a vector of Options, where `Some`s contain the coordinate of an invalid block and `None`s come from valid blocks. Then I compact it down into just a vector of coordinates, then iterate through and print them. This seems like a long way round.

Improvements:
- [x] Make it compile
- [x] Check that progress reporting isn't going to kill the piping (shouldn't if it can come out on STDERR, but I don't think I've set that up right)
- [ ] Differentiate between errors to determine whether to rethrow or call the block invalid
- [ ] Factor a bunch of the block iteration stuff out for maintainability
- [ ] Scrap the whole thing and just iterate over blocks which actually exist rather than trying to reach into the file system for every block which could exist. Some performance gains, especially on sparse datasets, but limits the utility to the filesystem implementation (which admittedly is all that exists right now, and is what the tool assumes anyway if it's going to print file paths)